### PR TITLE
Command `$moji {str}` Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 env
+.gitignore
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ env
 .gitignore
 .vscode
 font.tiff
-docker-compose.yml
+*.png

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 env
 .gitignore
 .vscode
+font.tiff
 docker-compose.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 env
 .gitignore
 .vscode
-font.tiff
+*.tff
 *.png

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 env
 .gitignore
 .vscode
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.6
+
+COPY . /app
+WORKDIR /app
+
+RUN pip3 install --upgrade -r requirements.txt
+
+CMD ["python", "-u", "bot.py"]

--- a/bot.py
+++ b/bot.py
@@ -8,11 +8,11 @@ from PIL import Image, ImageDraw, ImageFont
 
 BOT_TOKEN = os.environ["BOT_TOKEN"]
 FONT_URL = os.environ["FONT_URL"]
-FONT_PATH = "font.tiff"
+FONT_PATH = "font.tff"
 TMP_IMAGE_PATH = "tmp.png"
 
 # get font from remote
-if len(FONT_URL) > 0:
+if (len(FONT_URL) > 0) and not(os.path.exists(FONT_PATH)):
     print("font download from %s" % FONT_URL)
     urllib.request.urlretrieve(FONT_URL, FONT_PATH)
 

--- a/bot.py
+++ b/bot.py
@@ -11,6 +11,7 @@ bot = commands.Bot(command_prefix='$')
 
 @bot.event
 async def on_ready():
+    print("== ikanostage ==")
     print(bot.user.name)
     print(bot.user.id)
 

--- a/bot.py
+++ b/bot.py
@@ -4,8 +4,15 @@ import urllib.request
 import json
 import os
 import random
+from PIL import Image, ImageDraw, ImageFont
 
 BOT_TOKEN = os.environ["BOT_TOKEN"]
+FONT_URL = os.environ["FONT_URL"]
+
+# get font from remote
+if len(FONT_URL) > 0:
+    print("font download from %s" % FONT_URL)
+    urllib.request.urlretrieve(FONT_URL, "font.tiff")
 
 bot = commands.Bot(command_prefix='$')
 

--- a/bot.py
+++ b/bot.py
@@ -8,11 +8,26 @@ from PIL import Image, ImageDraw, ImageFont
 
 BOT_TOKEN = os.environ["BOT_TOKEN"]
 FONT_URL = os.environ["FONT_URL"]
+FONT_PATH = "font.tiff"
+TMP_IMAGE_PATH = "tmp.png"
 
 # get font from remote
 if len(FONT_URL) > 0:
     print("font download from %s" % FONT_URL)
-    urllib.request.urlretrieve(FONT_URL, "font.tiff")
+    urllib.request.urlretrieve(FONT_URL, FONT_PATH)
+
+def make_image(text, font_size=32, font_color="white"):
+    font = ImageFont.truetype(FONT_PATH, font_size)
+    # get fontsize
+    tmp = Image.new('RGBA', (1, 1), (0, 0, 0, 0)) # dummy for get text_size
+    tmp_d = ImageDraw.Draw(tmp)
+    text_size = tmp_d.textsize(text, font) # (width, heightが手に入る)
+    # draw text
+    img = Image.new('RGBA', text_size, (0, 0, 0, 0)) # background: transparent
+    img_d = ImageDraw.Draw(img)
+    img_d.text((0, 0), text, fill=font_color, font=font)
+    img.save(TMP_IMAGE_PATH)
+
 
 bot = commands.Bot(command_prefix='$')
 
@@ -69,5 +84,9 @@ async def buki():
 ```\
         ''' % (b["name"][region], b["sub"]["name"][region], b["special"]["name"][region]))
 
+@bot.command(pass_context=True)
+async def moji(ctx, str):
+    make_image(str)
+    await bot.send_file(ctx.message.channel, TMP_IMAGE_PATH)
 
 bot.run(BOT_TOKEN)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,0 @@
-ikanostage:
-  build: ./
-  volumes:
-    - ./:/app # for debug, source-code reload
-  environment: 
-    - BOT_TOKEN=<token here>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+ikanostage:
+  build: ./
+  volumes:
+    - ./:/app # for debug, source-code reload
+  environment: 
+    - BOT_TOKEN=
+    - FONT_URL=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+ikanostage:
+  build: ./
+  volumes:
+    - ./:/app # for debug, source-code reload
+  environment: 
+    - BOT_TOKEN=<token here>

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ discord==0.0.2
 discord.py==0.16.12
 multidict==4.3.1
 websockets==3.4
+pillow==5.4.1


### PR DESCRIPTION
荒削りですが指定されたフォント(.tiff)をDLして描画するコマンド`$moji`をサポートしました。

font-dlとアップロードイメージ作成のためにローカルファイルの書き込みが発生します。herokuサポートについては要確認をお願いします。

![2019-03-04 23 56 33](https://user-images.githubusercontent.com/4300987/53741238-49e3c500-3ed9-11e9-90c7-5ec71b41e960.png)
